### PR TITLE
Fix login flow

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -9,11 +9,8 @@ async function check_session( { event, resolve } ) {
 		return await resolve( event );
 	}
 
-	/** @type {import('./lib/schema').Session} */
-	let session;
-
 	try {
-		session = validate_session( session_cookie );
+		const session = validate_session( session_cookie );
 		event.locals.session = session;
 	} catch {
 		delete_session_cookies( event.cookies );

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,7 +1,8 @@
 import { delete_session_cookies, validate_session } from '$lib/utils.server.js';
+import { sequence } from '@sveltejs/kit/hooks';
 
 /** @type {import('@sveltejs/kit').Handle} */
-export const handle = async ( { event, resolve } ) => {
+async function check_session( { event, resolve } ) {
 	const session_cookie = event.cookies.get( 'session' );
 
 	if ( ! session_cookie ) {
@@ -19,4 +20,6 @@ export const handle = async ( { event, resolve } ) => {
 	}
 
 	return await resolve( event );
-};
+}
+
+export const handle = sequence( check_session );

--- a/src/lib/utils.server.js
+++ b/src/lib/utils.server.js
@@ -22,7 +22,7 @@ export function get_session_cookie_options() {
 		httpOnly: true,
 		maxAge: 60 * 60 * 24 * 7,
 		path: '/',
-		sameSite: 'strict',
+		sameSite: 'lax',
 		secure: process.env.NODE_ENV === 'production',
 	};
 }

--- a/src/routes/login/+page.server.js
+++ b/src/routes/login/+page.server.js
@@ -97,7 +97,6 @@ export const load = async ( { cookies, locals, url } ) => {
 
 	return {
 		auth_rejected: url.searchParams.get( 'success' ) === 'false',
-		has_auth: new_session !== undefined, // Work-around for Firefox. Aaaaaargh!!!111
 		require_access_key: get_access_keys().length > 0,
 		require_wp_url: ! get_wp_auth_endpoint_from_env(),
 	};

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,6 +1,5 @@
 <script>
 	import { applyAction, enhance } from '$app/forms';
-	import { goto } from '$app/navigation';
 	import Alert from '$lib/components/alert.svelte';
 	import ContentWrap from '$lib/components/content-wrap.svelte';
 	import TextField from '$lib/components/text-field.svelte';
@@ -35,12 +34,6 @@
 			};
 		} else {
 			alert = null;
-		}
-	} );
-
-	$effect( () => {
-		if ( data.has_auth ) {
-			goto( '/', { invalidateAll: true } );
 		}
 	} );
 </script>


### PR DESCRIPTION
This sets the `sameSite` cookie option to `lax` as Firefox strips all cookies with `sameSite` option set to `strict` on redirects.